### PR TITLE
Add page.extra.static_thumbnail in base.html

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -50,6 +50,8 @@
 
     {% if page.extra.thumbnail %}
     <meta property="og:image" content="{{ get_url(path=page.path ~ page.extra.thumbnail) }}">
+    {% elif page.extra.static_thumbnail %}
+    <meta property="og:image" content="{{ get_url(path=page.extra.static_thumbnail) }}">
     {% elif config.extra.default_og_image %}
     <meta property="og:image" content="{{ get_url(path=config.extra.default_og_image) }}">
     {% endif %}


### PR DESCRIPTION
The current thumbnail is based on the relative path to the current page. But, what if you have your images in the static folder? Currently, it's not possible to add any thumbnail in this context.

For this reason, I added another extra property: `static_thumbnail` where it will look from the static folder directly, independently from the page path.