### PR TITLE
Allow absolute static_thumbnail

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -49,11 +49,15 @@
     {% endif %}
 
     {% if page.extra.thumbnail %}
-    <meta property="og:image" content="{{ get_url(path=page.path ~ page.extra.thumbnail) }}">
+      <meta property="og:image" content="{{ get_url(path=page.path ~ page.extra.thumbnail) }}">
     {% elif page.extra.static_thumbnail %}
-    <meta property="og:image" content="{{ get_url(path=page.extra.static_thumbnail) }}">
+      {%if page.extra.static_thumbnail is containing("http") %}
+        <meta property="og:image" content="{{ page.extra.static_thumbnail }}">
+      {% else %}
+        <meta property="og:image" content="{{ get_url(path=page.extra.static_thumbnail) }}">
+      {% endif %}
     {% elif config.extra.default_og_image %}
-    <meta property="og:image" content="{{ get_url(path=config.extra.default_og_image) }}">
+        <meta property="og:image" content="{{ get_url(path=config.extra.default_og_image) }}">
     {% endif %}
 
     {% block description %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -51,7 +51,7 @@
     {% if page.extra.thumbnail %}
       <meta property="og:image" content="{{ get_url(path=page.path ~ page.extra.thumbnail) }}">
     {% elif page.extra.static_thumbnail %}
-      {%if page.extra.static_thumbnail is containing("http") %}
+      {%if page.extra.static_thumbnail is matching("^http[s]?://") %}
         <meta property="og:image" content="{{ page.extra.static_thumbnail }}">
       {% else %}
         <meta property="og:image" content="{{ get_url(path=page.extra.static_thumbnail) }}">


### PR DESCRIPTION
I just realized, what if you would like to point to an image/thumbnail that is in another domain? Currently, it's not possible, because it's always prefixing with the current website (using `get_url(path=page.extra.static_thumbnail)`).

### Proposal

Check if the `static_thumbnail` contains the absolute URL (checking `http://` or `https://`), and in case it is an absolute path, then use it as it is, without using the `get_url()` function. Otherwise, fallback as the previous behavior.