### PR TITLE
Add footer to the base template

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -43,6 +43,10 @@ footer_about = """
 A simple dev-blog theme created by Bennett. You can follow him on [Github](https://github.com/bennetthardwick) (if you like).
 """
 
+footer_page = """
+© 2021, all rights reserved
+"""
+
 not_found_message = """
 This is not the page you're looking for... return back to [safety?](/)
 """

--- a/sass/normalize.scss
+++ b/sass/normalize.scss
@@ -349,3 +349,9 @@ template {
 [hidden] {
   display: none;
 }
+
+footer.footer-page {
+  margin-top: 28px;
+  text-align: center;
+  font-size: 0.8em;
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -114,5 +114,12 @@
     <main>
     {% block content %} {% endblock content %}
     </main>
+    <footer class="footer-page">
+    {% block footer %}
+      {% if config.extra.footer_page %}
+        {{ config.extra.footer_page | markdown | safe }}
+      {% endif %}
+    {% endblock footer %}
+    </footer>
   </body>
 </html>


### PR DESCRIPTION
Configurable by `footer_page` in the `config.toml`.

The difference between `footer_page` and `footer_about` is that the `footer_page` is for the entire site, while the `footer_about` is just for the posts

## 🖼️ Screenshots

<img width="779" alt="Screenshot 2021-06-19 at 12 24 31" src="https://user-images.githubusercontent.com/5256287/122639275-4ea80380-d0f9-11eb-9b17-88ad87f600f4.png">

<img width="751" alt="Screenshot 2021-06-19 at 12 24 44" src="https://user-images.githubusercontent.com/5256287/122639289-55cf1180-d0f9-11eb-88cc-f860cc059254.png">

<img width="757" alt="Screenshot 2021-06-19 at 12 24 55" src="https://user-images.githubusercontent.com/5256287/122639300-5cf61f80-d0f9-11eb-83e2-69e6b4595314.png">

<img width="738" alt="Screenshot 2021-06-19 at 12 25 04" src="https://user-images.githubusercontent.com/5256287/122639305-62536a00-d0f9-11eb-8a97-ce503f627a8a.png">


