### PR TITLE
fix profile image for zola 0.14

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -7,7 +7,7 @@ command = "zola build"
 
 [build.environment]
 # Set the version name that you want to use and Netlify will automatically use it.
-ZOLA_VERSION = "0.11.0"
+ZOLA_VERSION = "0.14.0"
 
 # The magic for deploying previews of branches.
 # We need to override the base url with whatever url Netlify assigns to our

--- a/templates/base.html
+++ b/templates/base.html
@@ -18,15 +18,12 @@
     <meta name="theme-color" content="{{ config.extra.accent }}" />
 
     {% if config.extra.profile_small %}
-      <link rel="icon" href="{{ resize_image(path=config.extra.profile_small, width=48, height=48, op="fill") }}" />
-      <link rel="apple-touch-icon" sizes="48x48" href="{{ resize_image(path=config.extra.profile_small, width=48, height=48, op="fill") }}" />
-      <link rel="apple-touch-icon" sizes="72x72" href="{{ resize_image(path=config.extra.profile_small, width=72, height=72, op="fill") }}" />
-      <link rel="apple-touch-icon" sizes="96x96" href="{{ resize_image(path=config.extra.profile_small, width=96, height=96, op="fill") }}" />
-      <link rel="apple-touch-icon" sizes="144x144" href="{{ resize_image(path=config.extra.profile_small, width=144, height=144, op="fill") }}" />
-      <link rel="apple-touch-icon" sizes="192x192" href="{{ resize_image(path=config.extra.profile_small, width=192, height=192, op="fill") }}" />
-      <link rel="apple-touch-icon" sizes="256x256" href="{{ resize_image(path=config.extra.profile_small, width=256, height=256, op="fill") }}" />
-      <link rel="apple-touch-icon" sizes="384x384" href="{{ resize_image(path=config.extra.profile_small, width=384, height=384, op="fill") }}" />
-      <link rel="apple-touch-icon" sizes="512x512" href="{{ resize_image(path=config.extra.profile_small, width=512, height=512, op="fill") }}" />
+      {% set icon = resize_image(path=config.extra.profile_small, width=48, height=48, op="fill") -%}
+      <link rel="icon" href="{{ icon.url }}" />
+      {% for size in [48,72,96,144,192,256,384,512] -%}
+        {% set icon = resize_image(path=config.extra.profile_small, width=size, height=size, op="fill") -%}
+        <link rel="apple-touch-icon" sizes="{{size}}x{{size}}" href="{{ icon.url }}" />
+      {% endfor %}
     {% endif %}
 
     {% if config.extra.gtag %}
@@ -80,7 +77,8 @@
       <link rel="prerender" href="{{ link.path }}" />
     {% endfor %}
 
-    <link rel="prefetch" href="{{ resize_image(path=config.extra.profile_small, width=50, height=50, op="fill") }}" />
+    {% set icon = resize_image(path=config.extra.profile_small, width=50, height=50, op="fill") -%}
+    <link rel="prefetch" href="{{ icon.url }}" />
 
     <title>
       {% block title %}
@@ -102,7 +100,7 @@
     {% block header %}
       <header>
         <a class="profile-icon" href="/">
-          <img src="{{ resize_image(path=config.extra.profile_small, width=50, height=50, op="fill") }}" alt="profile picture">
+          <img src="{{ icon.url }}" alt="profile picture">
         </a>
         <nav>
           {% for link in config.extra.nav %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,7 +5,8 @@
 {% endblock styles %}
 
 {% block posthead %}
-  <link rel="prefetch" href="{{ resize_image(path=config.extra.profile_large, width=280, height=373, op="fill") }}">
+{% set profile_image = resize_image(path=config.extra.profile_large, width=280, height=373, op="fill") %}
+  <link rel="prefetch" href="{{ profile_image.url }}">
 
   {% if config.extra.latest_text %}
     {% set blog_path = "blog" %}
@@ -22,9 +23,10 @@
 
 
 {% block content %}
+{% set profile_image = resize_image(path=config.extra.profile_large, width=280, height=373, op="fill") %}
   <div class="profile">
     <div class="profile-container">
-      <img src="{{ resize_image(path=config.extra.profile_large, width=280, height=373, op="fill") }}" alt="profile picture">
+      <img src="{{ profile_image.url }}" alt="profile picture">
     </div>
   </div>
   <div class="content">


### PR DESCRIPTION
zola 0.14.0 introduced a breaking change, resize_image function now
returns an object instead of just the URL. This commit fixes the way the
profile images are handled.