### PR TITLE
Add nice table formatting

### DIFF
--- a/sass/main.scss
+++ b/sass/main.scss
@@ -102,5 +102,5 @@ table tbody tr:nth-of-type(even) {
 }
 
 table tbody tr:last-of-type {
-    border-bottom: 2px solid #009879;
+    border-bottom: 2px solid var(--accent-color);
 }

--- a/sass/main.scss
+++ b/sass/main.scss
@@ -71,3 +71,36 @@ img {
     margin-bottom: 0.5rem;
   }
 }
+
+table {
+  border-collapse: collapse;
+  margin: 25px auto;
+  font-size: 0.9em;
+  font-family: sans-serif;
+  min-width: 400px;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.15);
+}
+
+thead tr {
+  background-color: var(--accent-color);
+  color: #ffffff;
+  text-align: left;
+}
+
+table th,
+table td {
+    padding: 10px 12px;
+}
+
+
+table tbody tr {
+    border-bottom: 1px solid #dddddd;
+}
+
+table tbody tr:nth-of-type(even) {
+    background-color: #f3f3f3;
+}
+
+table tbody tr:last-of-type {
+    border-bottom: 2px solid #009879;
+}


### PR DESCRIPTION
I don't expect that this change will be accepted, as formatting is very subjective. For number-heavy tables the previous formatting was not very legible.

Before:

<img width="697" alt="Screenshot 2021-09-22 at 12 27 34" src="https://user-images.githubusercontent.com/1117749/134327785-0a4a4492-f516-40e1-8bc6-c5de4174bdd0.png">

After:

<img width="697" alt="Screenshot 2021-09-22 at 12 27 47" src="https://user-images.githubusercontent.com/1117749/134327809-3a3aea28-1595-4fbc-8414-7ad4e5834485.png">

