### PR TITLE
Add dark mode support

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -23,6 +23,8 @@ taxonomies = [
 
 [extra]
 
+dark_mode = false
+
 nav = [
   { name = "About", path = "/about/" },
   { name = "Blog", path = "/blog/" }

--- a/sass/index.scss
+++ b/sass/index.scss
@@ -99,6 +99,8 @@ main {
 }
 
 body {
+  background-color: var(--body-bg);
+  color: var(--body-color);
   box-sizing: border-box;
   display: flex;
   align-items: center;

--- a/sass/main.scss
+++ b/sass/main.scss
@@ -1,5 +1,9 @@
 @import "./normalize.scss", "./text.scss";
 
+body {
+  background-color: var(--body-bg);
+  color: var(--body-color);
+}
 
 .post-preview {
   h3.post-title {
@@ -83,7 +87,7 @@ table {
 
 thead tr {
   background-color: var(--accent-color);
-  color: #ffffff;
+  color: var(--accent-overlay-color);
   text-align: left;
 }
 
@@ -94,11 +98,11 @@ table td {
 
 
 table tbody tr {
-    border-bottom: 1px solid #dddddd;
+    border-bottom: 1px solid var(--table-border-bottom);
 }
 
 table tbody tr:nth-of-type(even) {
-    background-color: #f3f3f3;
+    background-color: var(--table-bg-even);
 }
 
 table tbody tr:last-of-type {

--- a/sass/text.scss
+++ b/sass/text.scss
@@ -21,6 +21,7 @@ h4,
 h5,
 h6 {
   font-weight: 500;
+  color: var(--heading-color);
 }
 
 body {

--- a/templates/base.html
+++ b/templates/base.html
@@ -12,7 +12,32 @@
       :root {
         --accent-color: {{ config.extra.accent }};
         --accent-color-light: {{ config.extra.accent_light }};
+        --accent-overlay-color: #fff;
+        --body-bg: #fff;
+        --body-color: #000;
+        --heading-color: #000;
+        --table-bg-even: #f3f3f3;
+        --table-border-bottom: #dddddd;
       }
+      {% if config.extra.dark_mode %}
+        @media (prefers-color-scheme: dark) {
+          :root {
+            --accent-overlay-color: #dee2e6;
+            --body-bg: #212529;
+            --body-color: #abb2bf;
+            --heading-color: #dee2e6;
+            --table-bg-even: #2d3237;
+            --table-border-bottom: #697077;
+          }
+          img {
+            opacity: .75;
+            transition: opacity .5s ease-in-out;
+          }
+          img:hover {
+            opacity: 1;
+          }
+        }
+      {% endif %}
     </style>
 
     <meta name="theme-color" content="{{ config.extra.accent }}" />


### PR DESCRIPTION
Dark mode can be activated by setting `dark_mode  = true` in `config.toml`.

I'm no designer, and no CSS expert, so this is kind of "hacked in" as best I saw fit.

Before:
<img width="715" alt="Screenshot 2021-09-24 at 10 22 22" src="https://user-images.githubusercontent.com/1117749/134642590-057bf698-e1ae-4478-bdf1-8f92b6cba814.png">

With dark mode:
<img width="715" alt="Screenshot 2021-09-24 at 10 22 31" src="https://user-images.githubusercontent.com/1117749/134642596-6c1aef2b-8ed4-4ed8-be6c-55d46e8615bf.png">


